### PR TITLE
feat: 解决 iOS 26.1 下 Apple Intelligence 无法调用 ChatGPT 问题

### DIFF
--- a/Surge/Ruleset/Extra/AI.list
+++ b/Surge/Ruleset/Extra/AI.list
@@ -5,6 +5,7 @@ DOMAIN,apple-relay.cloudflare.com
 DOMAIN,apple-relay.fastly-edge.com
 DOMAIN,cp4.cloudflare.com
 DOMAIN,guzzoni.apple.com
+DOMAIN,gspe1-ssl.ls.apple.com
 
 # Anthropic
 # > Claude


### PR DESCRIPTION
添加 gspe1-ssl.ls.apple.com 域名到 Apple 相关条目