### PR TITLE
feat: 在 AI.list 中添加 Doubao Cici（豆包海外版）

### DIFF
--- a/Surge/Ruleset/Extra/AI.list
+++ b/Surge/Ruleset/Extra/AI.list
@@ -86,3 +86,8 @@ DOMAIN,pplx-res.cloudinary.com
 # xAI
 DOMAIN-SUFFIX,grok.com
 DOMAIN-SUFFIX,x.ai
+
+# Doubao
+# > Doubao Cici
+DOMAIN-SUFFIX,cici.com,extended-matching
+DOMAIN-SUFFIX,ciciai.com,extended-matching


### PR DESCRIPTION
Cici should not be connected via a proxy in Hong Kong or the United States. You may select proxies in Japan or Singapore for AI.list for your reference.